### PR TITLE
Allwinner H616 firmware support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+arm-trusted-firmware (2.10.0+dfsg-1+wb2) unstable; urgency=medium
+
+  * add Allwinner H616 build
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Thu, 29 Feb 2024 19:16:33 +0600
+
 arm-trusted-firmware (2.10.0+dfsg-1+wb1) unstable; urgency=medium
 
   * configure build on Wiren Board CI (bullseye), no major functional changes

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,7 @@ else
 VERBOSE=1
 endif
 
-platforms := g12a gxbb sun50i_a64 sun50i_h6 rcar rk3328 rk3399 rpi3 rpi4 imx8mn imx8mm
+platforms := g12a gxbb sun50i_a64 sun50i_h6 sun50i_h616 rcar rk3328 rk3399 rpi3 rpi4 imx8mn imx8mm
 # Disable building of imx8mq, as it is not well supported upstream.
 #platforms_nodebug := imx8mq
 
@@ -39,6 +39,9 @@ imx8mm_uart4_assigns := IMX_BOOT_UART_BASE=0x30A60000
 #   * sun50i_h6_no_pmic: skip regulator setup
 sun50i_h6_subplatforms := sun50i_h6 sun50i_h6_no_pmic
 sun50i_h6_no_pmic_assigns := SUNXI_SETUP_REGULATORS=0
+
+sun50i_h616_subplatforms := sun50i_h616 sun50i_h616_no_pmic
+sun50i_h616_no_pmic_assigns := SUNXI_SETUP_REGULATORS=0
 
 rk3328_targets := bl31/bl31.elf
 rk3399_targets := bl31/bl31.elf

--- a/plat/allwinner/sun50i_h616/sunxi_power.c
+++ b/plat/allwinner/sun50i_h616/sunxi_power.c
@@ -66,6 +66,7 @@ static int rsb_init(void)
 
 int sunxi_pmic_setup(uint16_t socid, const void *fdt)
 {
+#if SUNXI_SETUP_REGULATORS == 1
 	int ret;
 
 	INFO("PMIC: Probing AXP305 on RSB\n");
@@ -91,6 +92,10 @@ int sunxi_pmic_setup(uint16_t socid, const void *fdt)
 		return ret;
 
 	return 0;
+#else
+	/* Skipping PMIC configuration */
+	return 1;
+#endif
 }
 
 void sunxi_power_down(void)


### PR DESCRIPTION
Добавил конфигурацию для сборки bl31 для H616 (T507). Пришлось принудительно выключить настройку PMIC, потому что нашему ядру сейчас что-то не нравится, если её оставить (возможно, починю потом в ядре, в таком виде могут не принять в debian). Скорее всего, там какая-то периферия в soc остаётся сконфигурированной наполовину и linux это не нравится.

Ну и ругани в логах так получилось поменьше.

Проверил на нашем тестовом u-boot, собирается и работает